### PR TITLE
pass jetton_amount in own bit size

### DIFF
--- a/examples/wallet/common/batch_transfer_jetton.py
+++ b/examples/wallet/common/batch_transfer_jetton.py
@@ -17,25 +17,25 @@ async def main() -> None:
             TransferJettonData(
                 destination="UQ...",
                 jetton_master_address="EQ...",
-                jetton_amount=0.01,
+                jetton_amount=1,
                 forward_payload="Hello from pytoniq-tools!",
             ),
             TransferJettonData(
                 destination="UQ...",
                 jetton_master_address="EQ...",
-                jetton_amount=0.02,
+                jetton_amount=2,
                 forward_payload="Hello from pytoniq-tools!",
             ),
             TransferJettonData(
                 destination="UQ...",
                 jetton_master_address="EQ...",
-                jetton_amount=0.03,
+                jetton_amount=3,
                 forward_payload="Hello from pytoniq-tools!",
             ),
             TransferJettonData(
                 destination="UQ...",
                 jetton_master_address="EQ...",
-                jetton_amount=0.04,
+                jetton_amount=4,
                 forward_payload="Hello from pytoniq-tools!",
             ),
         ]

--- a/examples/wallet/common/transfer_jetton.py
+++ b/examples/wallet/common/transfer_jetton.py
@@ -14,7 +14,7 @@ async def main() -> None:
     tx_hash = await wallet.transfer_jetton(
         destination="UQ...",
         jetton_master_address="EQ...",
-        jetton_amount=0.01,
+        jetton_amount=1,
         forward_payload="Hello from pytoniq-tools!"
     )
 

--- a/examples/wallet/highload/transfer_jetton.py
+++ b/examples/wallet/highload/transfer_jetton.py
@@ -17,19 +17,19 @@ async def main() -> None:
             TransferJettonData(
                 destination="UQ...",
                 jetton_master_address="EQ...",
-                jetton_amount=0.01,
+                jetton_amount=1,
                 forward_payload="Hello from pytoniq-tools!"
             ),
             TransferJettonData(
                 destination="UQ...",
                 jetton_master_address="EQ...",
-                jetton_amount=0.01,
+                jetton_amount=1,
                 forward_payload="Hello from pytoniq-tools!"
             ),
             TransferJettonData(
                 destination="UQ...",
                 jetton_master_address="EQ...",
-                jetton_amount=0.01,
+                jetton_amount=1,
                 forward_payload="Hello from pytoniq-tools!"
             )
         ]

--- a/pytoniq_tools/wallet/_base.py
+++ b/pytoniq_tools/wallet/_base.py
@@ -438,7 +438,7 @@ class Wallet(Contract):
             self,
             destination: Union[Address, str],
             jetton_master_address: Union[Address, str],
-            jetton_amount: Union[int, float],
+            jetton_amount: int,
             forward_payload: Optional[Cell, str] = Cell.empty(),
             forward_amount: Optional[int, float] = 0.001,
             amount: Optional[Union[int, float]] = 0.05,
@@ -481,7 +481,7 @@ class Wallet(Contract):
             body=Jetton.build_transfer_body(
                 recipient_address=destination,
                 response_address=self.address,
-                jetton_amount=amount_to_nano(jetton_amount),
+                jetton_amount=jetton_amount,
                 forward_payload=forward_payload,
                 forward_amount=amount_to_nano(forward_amount),
             )
@@ -516,7 +516,7 @@ class Wallet(Contract):
                     body=Jetton.build_transfer_body(
                         recipient_address=data.destination,
                         response_address=self.address,
-                        jetton_amount=amount_to_nano(data.jetton_amount),
+                        jetton_amount=data.jetton_amount,
                         forward_payload=data.forward_payload,
                         forward_amount=amount_to_nano(data.forward_amount),
                     ),

--- a/pytoniq_tools/wallet/data.py
+++ b/pytoniq_tools/wallet/data.py
@@ -97,7 +97,7 @@ class TransferJettonData:
             self,
             destination: Union[Address, str],
             jetton_master_address: Union[Address, str],
-            jetton_amount: Union[int, float],
+            jetton_amount: int,
             forward_payload: Optional[Union[Cell, str]] = Cell.empty(),
             forward_amount: Optional[int, float] = 0.001,
             amount: Union[int, float] = 0.05,


### PR DESCRIPTION
in the case when the contract token capacity is not equal to 9, it is necessary to transmit a different value of the amount

allow the client to transmit the already converted value taking into account the token capacity